### PR TITLE
Update states, refactor some stuff, add more customization options

### DIFF
--- a/cuckoo/community.sls
+++ b/cuckoo/community.sls
@@ -1,5 +1,5 @@
 community:
   cmd.run:
-    - name: cuckoo community
+    - name: cuckoo --cwd {{ salt['pillar.get']('cuckoo:cwd') }} community
     - runas: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - cwd: {{ salt['pillar.get']('cuckoo:cwd') }}

--- a/cuckoo/files/cuckoo-rooter.service
+++ b/cuckoo/files/cuckoo-rooter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Cuckoo Rooter
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+StandardOutput=tty
+ExecStart=/usr/local/bin/cuckoo --cwd {{ salt['pillar.get']('cuckoo:cwd') }} rooter
+WorkingDirectory={{ salt['pillar.get']('cuckoo:cwd') }}
+
+[Install]
+WantedBy=multi-user.target

--- a/cuckoo/files/supervisord.conf
+++ b/cuckoo/files/supervisord.conf
@@ -1,0 +1,36 @@
+[supervisord]
+logfile = {{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/cwd/supervisord/log.log
+pidfile = {{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/cwd/supervisord/pidfile
+user = cuckoo
+
+[supervisorctl]
+serverurl = unix://{{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/cwd/supervisord/unix.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file = {{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/cwd/supervisord/unix.sock
+
+[program:cuckoo-daemon]
+command = cuckoo -d -m 10000
+user = cuckoo
+startsecs = 30
+autorestart = true
+
+[program:cuckoo-process]
+command = cuckoo -d process p%(process_num)d
+process_name = cuckoo-process_%(process_num)d
+numprocs = {{ salt['pillar.get']('cuckoo:process', '4') }} 
+user = cuckoo
+autorestart = true
+
+[group:cuckoo]
+programs = cuckoo-daemon, cuckoo-process
+
+[program:distributed]
+command = python -m cuckoo.distributed.worker
+user = cuckoo
+autostart = false
+autorestart = true
+environment = CUCKOO_APP="worker",CUCKOO_CWD="{{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/cwd"

--- a/cuckoo/init.sls
+++ b/cuckoo/init.sls
@@ -35,7 +35,7 @@ api_nginx:
 limits.conf:
   file.append:
     - name: /etc/security/limits.conf
-    - source: salt://cuckoo/files/limits.conf
+    - source: salt://{{ slspath }}/files/limits.conf
 
 uwsgi:
   service.running:

--- a/cuckoo/install.sls
+++ b/cuckoo/install.sls
@@ -1,7 +1,7 @@
 package:
   file.managed:
     - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/{{ salt['pillar.get']('cuckoo:version') }}
-    - source: salt://cuckoo/files/{{ salt['pillar.get']('cuckoo:version') }}
+    - source: salt://{{ slspath }}/files/{{ salt['pillar.get']('cuckoo:version') }}
 
 install:
   cmd.run:
@@ -22,6 +22,11 @@ init:
       - cmd: install
       - file: {{ salt['pillar.get']('cuckoo:cwd') }}
 
+/etc/supervisor/supervisord.conf:
+  file.symlink:
+    - target: {{ salt['pillar.get']('cuckoo:cwd') }}/supervisord.conf
+    - force: True
+
 conf:
   file.recurse:
     - name: {{ salt['pillar.get']('cuckoo:cwd') }}/conf
@@ -30,4 +35,27 @@ conf:
     - file_mode: 644
     - dir_mode: 750
     - template: jinja
-    - source: salt://cuckoo/files/conf
+    - source: salt://{{ slspath }}/files/conf
+
+conf_supervisor:
+  file.managed:
+    - name: {{ salt['pillar.get']('cuckoo:cwd') }}/supervisord.conf
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - file_mode: 644
+    - dir_mode: 750
+    - source: salt://{{ slspath }}/files/supervisord.conf
+    - template: jinja
+    - require:
+      - file: conf
+
+cuckoo-rooter:
+  file.managed:
+    - name: /etc/systemd/system/cuckoo-rooter.service
+    - file_mode: 644
+    - template: jinja
+    - source: salt://{{ slspath }}/files/cuckoo-rooter.service
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      -file: cuckoo-rooter

--- a/cuckoo/removevms.sls
+++ b/cuckoo/removevms.sls
@@ -8,4 +8,4 @@ vbox_removevms:
 
 vmcloak_cleanup:
   file.absent:
-    - name: /home/{{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}/.vmcloak
+    - name: {{ salt['pillar.get']('cuckoo:home', '/home/cuckoo') }}/.vmcloak

--- a/cuckoo/start.sls
+++ b/cuckoo/start.sls
@@ -1,3 +1,7 @@
+start-rooter:
+  cmd.run:
+    - name: systemctl start cuckoo-rooter
+
 supervisord:
   cmd.run:
     # supervisord throws an error if it's already running
@@ -11,4 +15,5 @@ start:
     - runas: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - cwd: {{ salt['pillar.get']('cuckoo:cwd') }}
     - require:
+      - cmd: start-rooter
       - cmd: supervisord

--- a/cuckoo/stop.sls
+++ b/cuckoo/stop.sls
@@ -1,3 +1,7 @@
+stop_rooter:
+  cmd.run:
+    - name: systemctl stop cuckoo-rooter
+
 stop_cuckoo:
   cmd.run:
     - name: "supervisorctl stop cuckoo:"
@@ -14,3 +18,8 @@ kill_related:
   cmd.run:
     - name: "vmcloak-killvbox"
     - runas: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - ignore_retcode: True
+
+flush_iptables:
+  cmd.run:
+    - name: iptables -F

--- a/cuckoo/vmcloak.sls
+++ b/cuckoo/vmcloak.sls
@@ -26,34 +26,10 @@ vmcloak_workingdir:
     - require:
       - user: cuckoo_user
 
-{% if salt['pillar.get']('office:2007') != 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX' %}
-office2007.iso:
-  file.managed:
-    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/office2007.iso
-    - source: salt://cuckoo/files/office2007.iso
-    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - mode: 644
-    - require:
-      - file: vmcloak_workingdir
-{% endif %}
-
-{% if salt['pillar.get']('office:2010') != 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX' %}
-office2010.iso:
-  file.managed:
-    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/office2010.iso
-    - source: salt://cuckoo/files/office2010.iso
-    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - mode: 644
-    - require:
-      - file: vmcloak_workingdir
-{% endif %}
-
 archive_zip:
   file.managed:
     - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/archive.zip
-    - source: salt://cuckoo/files/archive.zip
+    - source: salt://{{ slspath }}/files/archive.zip
     - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - mode: 644
@@ -63,58 +39,12 @@ archive_zip:
 wallpaper_jpg:
   file.managed:
     - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/wallpaper.jpg
-    - source: salt://cuckoo/files/wallpaper.jpg
+    - source: salt://{{ slspath }}/files/wallpaper.jpg
     - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
     - mode: 644
     - require:
       - file: vmcloak_workingdir
-
-{% if salt['pillar.get']('vms:winxp:create') %}
-winxp_iso:
-  file.managed:
-    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/winxp.iso
-    - source: salt://cuckoo/files/winxp.iso
-    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - mode: 644
-    - require:
-      - file: vmcloak_workingdir
-
-winxp_mount:
-  mount.mounted:
-    - name: {{ salt['pillar.get']('vmcloak:isomountdir') }}/winxp
-    - device: {{ salt['pillar.get']('vmcloak:workingdir') }}/winxp.iso
-    - fstype: iso9660
-    - mkmnt: True
-    - persist: False
-    - opts: loop,ro
-    - require:
-      - file: winxp_iso
-{% endif %}
-
-{% if salt['pillar.get']('vms:win7x64:create') %}
-win7x64_iso:
-  file.managed:
-    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/win7x64.iso
-    - source: salt://cuckoo/files/win7x64.iso
-    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
-    - mode: 644
-    - require:
-      - file: vmcloak_workingdir
-
-win7x64_mount:
-  mount.mounted:
-    - name: {{ salt['pillar.get']('vmcloak:isomountdir') }}/win7x64
-    - device: {{ salt['pillar.get']('vmcloak:workingdir') }}/win7x64.iso
-    - fstype: udf
-    - mkmnt: True
-    - persist: False
-    - opts: loop,ro
-    - require:
-      - file: win7x64_iso
-{% endif %}
 
 {% if salt['pillar.get']('vmcloak:interface') %}
 vmcloak_iptables:

--- a/cuckoo/vms.sls
+++ b/cuckoo/vms.sls
@@ -2,6 +2,96 @@ include:
   - cuckoo.deps
   - cuckoo.vmcloak
 
+vmcloak_workingdir:
+  file.directory:
+    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - dir_mode: 755
+    - file_mode: 644
+    - recurse:
+      - user
+      - group
+      - mode
+    - makedirs: True
+
+{% if salt['pillar.get']('office:2007') != 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX' %}
+office2007.iso:
+  file.managed:
+    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/office2007.iso
+    - source: {{ salt['pillar.get']('vmcloak:iso:office2007') }}
+    - skip_verify: True
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - mode: 644
+    - replace: False
+    - require:
+      - file: vmcloak_workingdir
+{% endif %}
+
+{% if salt['pillar.get']('office:2010') != 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX' %}
+office2010.iso:
+  file.managed:
+    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/office2010.iso
+    - source: {{ salt['pillar.get']('vmcloak:iso:office2010') }}
+    - skip_verify: True
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - mode: 644
+    - replace: False
+    - require:
+      - file: vmcloak_workingdir
+{% endif %}
+
+{% if salt['pillar.get']('vms:winxp:create') %}
+winxp_iso:
+  file.managed:
+    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/winxp.iso
+    - source: {{ salt['pillar.get']('vmcloak:iso:winXPiso') }}
+    - skip_verify: True
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - mode: 644
+    - require:
+      - file: vmcloak_workingdir
+
+winxp_mount:
+  mount.mounted:
+    - name: {{ salt['pillar.get']('vmcloak:isomountdir') }}/winxp
+    - device: {{ salt['pillar.get']('vmcloak:workingdir') }}/winxp.iso
+    - fstype: iso9660
+    - mkmnt: True
+    - persist: False
+    - opts: loop,ro
+    - require:
+      - file: winxp_iso
+{% endif %}
+
+{% if salt['pillar.get']('vms:win7x64:create') %}
+win7x64_iso:
+  file.managed:
+    - name: {{ salt['pillar.get']('vmcloak:workingdir') }}/win7x64.iso
+    - source: {{ salt['pillar.get']('vmcloak:iso:win7x64iso') }}
+    - skip_verify: True
+    - user: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - group: {{ salt['pillar.get']('cuckoo:user', 'cuckoo') }}
+    - mode: 644
+    - replace: False
+    - require:
+      - file: vmcloak_workingdir
+
+win7x64_mount:
+  mount.mounted:
+    - name: {{ salt['pillar.get']('vmcloak:isomountdir') }}/win7x64
+    - device: {{ salt['pillar.get']('vmcloak:workingdir') }}/win7x64.iso
+    - fstype: udf
+    - mkmnt: True
+    - persist: False
+    - opts: loop,ro
+    - require:
+      - file: win7x64_iso
+{% endif %}
+
 vboxnet0_remove:
   cmd.run:
     - name: >

--- a/pillar.example
+++ b/pillar.example
@@ -13,6 +13,10 @@ cuckoo:
 
   # Cuckoo Working Directory.
   cwd: /home/cuckoo/cwd
+  # Cuckoo home dir
+  home: /home/cuckoo
+  # How many processing nodes to run
+  process: 4
 
 virtualbox:
   version: 5.1
@@ -295,8 +299,13 @@ conf:
     strings:
       enabled: 'yes'
     suricata:
-      enabled: 'no'
+      enabled: 'yes'
+      suricata: /usr/bin/suricata
       socket: /var/run/suricata/suricata-command.socket
+      conf: /etc/suricata/suricata.yaml
+      eve_log: eve.json
+      files_log: files-json.log
+      files_dir: files
     targetinfo:
       enabled: 'yes'
     virustotal:


### PR DESCRIPTION
Uhh this is a big one. Changelog:
- Made multiple salt source file definitons use the {{ slspath }} variable, so the cuckoo formula does not have to be in the salt master file_roots top level anymore i.e. can now also be something like `/srv/salt/foo/bar/cuckoo` instead of `/srv/salt/cuckoo` without breaking file management states
- New pillar values for customizing amount of processing nodes and fix suricata stuff
- Create custom systemd unit file for cuckoo-rooter
- Customizable supervisord config
- Move VM iso copy stuff from vmcloak.sls to vms.sls
- During start and stop also handle cuckoo-rooter and iptables